### PR TITLE
Fixed false positive on removal of overriden methods

### DIFF
--- a/src/Uno.PackageDiff.Tests/Given_AssemblyComparer.cs
+++ b/src/Uno.PackageDiff.Tests/Given_AssemblyComparer.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
@@ -40,8 +41,11 @@ namespace Uno.PackageDiff.Tests
 			Assert.AreEqual(0, r.InvalidTypes.Length);
 			Assert.AreEqual(0, r.InvalidEvents.Length);
 			Assert.AreEqual(0, r.InvalidFields.Length);
-			Assert.AreEqual(0, r.InvalidMethods.Length);
+			Assert.AreEqual(2, r.InvalidMethods.Length);
 			Assert.AreEqual(0, r.InvalidProperties.Length);
+
+			Assert.AreEqual("System.Void Uno.PackageDiff.Tests.Sources.When_DerivingClasses_Base::VirtualMethod2()", r.InvalidMethods.ElementAt(0).ToString());
+			Assert.AreEqual("System.Void Uno.PackageDiff.Tests.Sources.When_DerivingClasses_Base::VirtualMethod3()", r.InvalidMethods.ElementAt(1).ToString());
 		}
 
 		[TestMethod]

--- a/src/Uno.PackageDiff.Tests/Given_AssemblyComparer.cs
+++ b/src/Uno.PackageDiff.Tests/Given_AssemblyComparer.cs
@@ -31,6 +31,20 @@ namespace Uno.PackageDiff.Tests
 		}
 
 		[TestMethod]
+		public void When_DerivingClasses()
+		{
+			var context = _builder.BuildAssemblies();
+
+			var r = AssemblyComparer.CompareTypes(context.BaseAssembly, context.TargetAssembly);
+
+			Assert.AreEqual(0, r.InvalidTypes.Length);
+			Assert.AreEqual(0, r.InvalidEvents.Length);
+			Assert.AreEqual(0, r.InvalidFields.Length);
+			Assert.AreEqual(0, r.InvalidMethods.Length);
+			Assert.AreEqual(0, r.InvalidProperties.Length);
+		}
+
+		[TestMethod]
 		public void When_Target_MissingProperty()
 		{
 			var context = _builder.BuildAssemblies();
@@ -44,12 +58,12 @@ namespace Uno.PackageDiff.Tests
 			Assert.AreEqual(1, r.InvalidProperties.Length);
 			Assert.AreEqual("MyProperty", r.InvalidProperties.First().Name);
 		}
-		 
+
 		[TestMethod]
 		public void When_Target_Internal()
 		{
 			var context = _builder.BuildAssemblies();
-			
+
 			var r = AssemblyComparer.CompareTypes(context.BaseAssembly, context.TargetAssembly);
 
 			Assert.AreEqual(0, r.InvalidTypes.Length);

--- a/src/Uno.PackageDiff.Tests/ModuleBuilder.cs
+++ b/src/Uno.PackageDiff.Tests/ModuleBuilder.cs
@@ -6,6 +6,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Emit;
 using Microsoft.CodeAnalysis.Host;
 
 namespace Uno.PackageDiff.Tests
@@ -23,6 +24,13 @@ namespace Uno.PackageDiff.Tests
 			var stream = new MemoryStream();
 			var emitResult = compilation.Emit(stream);
 
+			if(!emitResult.Success)
+			{
+				var msg = string.Join("\n", emitResult.Diagnostics
+					.Where(d => d.Severity == DiagnosticSeverity.Error)
+					.Select(d => d.GetMessage()));
+				throw new InvalidOperationException($"Unable to compile source code.  Errors:\n{msg}");
+			}
 			stream.Position = 0;
 
 			return Mono.Cecil.AssemblyDefinition.ReadAssembly(stream);

--- a/src/Uno.PackageDiff.Tests/Sources/Given_AssemblyComparer_When_DerivingClasses.base.cs
+++ b/src/Uno.PackageDiff.Tests/Sources/Given_AssemblyComparer_When_DerivingClasses.base.cs
@@ -1,0 +1,18 @@
+namespace Uno.PackageDiff.Tests.Sources
+{
+	public class When_DerivingClasses : When_DerivingClasses_Base
+	{
+		public override void VirtualMethod()
+		{
+			base.VirtualMethod();
+		}
+	}
+
+	public class When_DerivingClasses_Base
+	{
+		public virtual void VirtualMethod()
+		{
+
+		}
+	}
+}

--- a/src/Uno.PackageDiff.Tests/Sources/Given_AssemblyComparer_When_DerivingClasses.base.cs
+++ b/src/Uno.PackageDiff.Tests/Sources/Given_AssemblyComparer_When_DerivingClasses.base.cs
@@ -2,17 +2,24 @@ namespace Uno.PackageDiff.Tests.Sources
 {
 	public class When_DerivingClasses : When_DerivingClasses_Base
 	{
-		public override void VirtualMethod()
+		public override void VirtualMethod1()
 		{
-			base.VirtualMethod();
+			base.VirtualMethod1();
 		}
 	}
 
 	public class When_DerivingClasses_Base
 	{
-		public virtual void VirtualMethod()
+		public virtual void VirtualMethod1()
 		{
+		}
 
+		public virtual void VirtualMethod2()
+		{
+		}
+
+		public virtual void VirtualMethod3()
+		{
 		}
 	}
 }

--- a/src/Uno.PackageDiff.Tests/Sources/Given_AssemblyComparer_When_DerivingClasses.target.cs
+++ b/src/Uno.PackageDiff.Tests/Sources/Given_AssemblyComparer_When_DerivingClasses.target.cs
@@ -1,0 +1,15 @@
+namespace Uno.PackageDiff.Tests.Sources
+{
+	public class When_DerivingClasses : When_DerivingClasses_Base
+	{
+		// "VirtualMethod" override removed here
+	}
+
+	public class When_DerivingClasses_Base
+	{
+		public virtual void VirtualMethod()
+		{
+
+		}
+	}
+}

--- a/src/Uno.PackageDiff.Tests/Sources/Given_AssemblyComparer_When_DerivingClasses.target.cs
+++ b/src/Uno.PackageDiff.Tests/Sources/Given_AssemblyComparer_When_DerivingClasses.target.cs
@@ -2,14 +2,19 @@ namespace Uno.PackageDiff.Tests.Sources
 {
 	public class When_DerivingClasses : When_DerivingClasses_Base
 	{
-		// "VirtualMethod" override removed here
+		// "VirtualMethod1" override removed here: not a breaking change
 	}
 
 	public class When_DerivingClasses_Base
 	{
-		public virtual void VirtualMethod()
+		public virtual void VirtualMethod1()
 		{
 
+		}
+		// "VirtualMethod2" virtual removed here: this one is breaking
+
+		public void VirtualMethod3() // no more virtual
+		{
 		}
 	}
 }

--- a/src/Uno.PackageDiff.Tests/Uno.PackageDiff.Tests.csproj
+++ b/src/Uno.PackageDiff.Tests/Uno.PackageDiff.Tests.csproj
@@ -4,6 +4,8 @@
 		<TargetFramework>netcoreapp2.1</TargetFramework>
 
 		<IsPackable>false</IsPackable>
+
+		<OutputType>Library</OutputType>
 	</PropertyGroup>
 
 	<ItemGroup>
@@ -24,9 +26,9 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-		<PackageReference Include="MSTest.TestAdapter" Version="1.3.2" />
-		<PackageReference Include="MSTest.TestFramework" Version="1.3.2" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+		<PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
+		<PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
 		<PackageReference Include="Mono.Cecil" Version="0.10.3" />
 		<PackageReference Include="Microsoft.CodeAnalysis" Version="2.8.2" />
 	</ItemGroup>

--- a/src/Uno.PackageDiff.Tests/Uno.PackageDiff.Tests.csproj
+++ b/src/Uno.PackageDiff.Tests/Uno.PackageDiff.Tests.csproj
@@ -4,8 +4,6 @@
 		<TargetFramework>netcoreapp2.1</TargetFramework>
 
 		<IsPackable>false</IsPackable>
-
-		<OutputType>Library</OutputType>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/src/Uno.PackageDiff/AssemblyComparer.cs
+++ b/src/Uno.PackageDiff/AssemblyComparer.cs
@@ -69,18 +69,19 @@ namespace Uno.PackageDiff
 					 from targetMethod in type.targetType.Methods
 					 let targetMethodParams = getMethodParamsSignature(targetMethod)
 					 where IsVisibleMethod(targetMethod)
+					 where !targetMethod.IsVirtual || !targetMethod.IsReuseSlot
 					 where !type.sourceType.Methods
 						.Any(sourceMethod =>
 						sourceMethod.Name == targetMethod.Name
 						&& targetMethodParams.SequenceEqual(getMethodParamsSignature(sourceMethod))
-						&& IsVisibleMethod(sourceMethod))
+						&& IsVisibleMethod(sourceMethod)
+						&& targetMethod.IsVirtual == sourceMethod.IsVirtual)
 					 select targetMethod;
 
 			return q1.ToArray();
 		}
 
-		private static bool IsVisibleMethod(MethodDefinition targetMethod)
-			=> (targetMethod != null && (targetMethod.IsPublic || targetMethod.IsFamily)) && !targetMethod.IsVirtual;
+		private static bool IsVisibleMethod(MethodDefinition targetMethod) => targetMethod != null && (targetMethod.IsPublic || targetMethod.IsFamily);
 
 		private static string ExpandMethod(MethodDefinition method)
 		{

--- a/src/Uno.PackageDiff/AssemblyComparer.cs
+++ b/src/Uno.PackageDiff/AssemblyComparer.cs
@@ -80,7 +80,7 @@ namespace Uno.PackageDiff
 		}
 
 		private static bool IsVisibleMethod(MethodDefinition targetMethod)
-			=> targetMethod != null ? targetMethod.IsPublic || targetMethod.IsFamily : false;
+			=> (targetMethod != null && (targetMethod.IsPublic || targetMethod.IsFamily)) && !targetMethod.IsVirtual;
 
 		private static string ExpandMethod(MethodDefinition method)
 		{


### PR DESCRIPTION
## Bugfix
Removal of an overriden method were falsely reported as a breaking change: it's not.

## PR Checklist

- [X] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [X] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal)
