### PR TITLE
feat: Ignore changes to an ignored type

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -91,7 +91,7 @@ jobs:
 - job: macOS
 
   pool:
-    vmImage: 'macOS-10.13'
+    vmImage: 'macOS-10.15'
 
   variables:
     NUGET_PACKAGES: $(Agent.WorkFolder)/.nuget

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -16,10 +16,7 @@ jobs:
       versionSpec: 4.9.1
       checkLatest: false
     
-  - task: GitVersion@4
-    # Ignore gitversion for forks, until this is fixed:
-    # https://developercommunity.visualstudio.com/content/problem/284991/public-vsts-previouw-cant-set-build-number-of-pr-b.html
-    condition: eq(variables['System.PullRequest.IsFork'], 'False')
+  - task: GitVersion@5
     inputs:
       updateAssemblyInfo: false
 

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -34,8 +34,8 @@
         <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
       </PropertyGroup>
       <ItemGroup>
-        <PackageReference Include="Microsoft.SourceLink.Vsts.Git" Version="1.0.0-beta-62925-02" PrivateAssets="All"/>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-62925-02" PrivateAssets="All"/>
+        <PackageReference Include="Microsoft.SourceLink.AzureRepos.Git" Version="1.0.0" PrivateAssets="All"/>
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
       </ItemGroup>
     </When>
   </Choose>

--- a/src/Uno.PackageDiff.Tests/Given_ReportAnalyzer.cs
+++ b/src/Uno.PackageDiff.Tests/Given_ReportAnalyzer.cs
@@ -35,5 +35,16 @@ namespace Uno.PackageDiff.Tests
 			Assert.IsNotNull(context.IgnoreSet);
 			Assert.IsTrue(ReportAnalyzer.IsDiffFailed(res, context.IgnoreSet));
 		}
+
+		[TestMethod]
+		public void When_Ignore_All_Changes_To_Type()
+		{
+			var context = _builder.BuildAssemblies();
+
+			var comparison = AssemblyComparer.CompareTypes(context.BaseAssembly, context.TargetAssembly);
+
+			Assert.IsNotNull(context.IgnoreSet);
+			Assert.IsFalse(ReportAnalyzer.IsDiffFailed(comparison, context.IgnoreSet));
+		}
 	}
 }

--- a/src/Uno.PackageDiff.Tests/Sources/Given_ReportAnalyzer_When_Ignore_All_Changes_To_Type.base.cs
+++ b/src/Uno.PackageDiff.Tests/Sources/Given_ReportAnalyzer_When_Ignore_All_Changes_To_Type.base.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Uno.PackageDiff.Tests.Sources
+{
+	public class When_Ignore_All_Changes_To_Type
+	{
+		public int OldProperty1 { get; }
+
+		public string OldProperty2 { get; protected set; }
+
+		public void OldMethod1(float f) { }
+
+		public double OldMethod2() => 42d;
+
+		public event Action OldEvent;
+	}
+}

--- a/src/Uno.PackageDiff.Tests/Sources/Given_ReportAnalyzer_When_Ignore_All_Changes_To_Type.diff.xml
+++ b/src/Uno.PackageDiff.Tests/Sources/Given_ReportAnalyzer_When_Ignore_All_Changes_To_Type.diff.xml
@@ -1,0 +1,10 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<DiffIgnore>
+  <IgnoreSets>
+    <IgnoreSet baseVersion="1.0.0">
+      <Types>
+        <Member fullName="Uno.PackageDiff.Tests.Sources.When_Ignore_All_Changes_To_Type"/>
+      </Types>
+    </IgnoreSet>
+  </IgnoreSets>
+</DiffIgnore>

--- a/src/Uno.PackageDiff.Tests/Sources/Given_ReportAnalyzer_When_Ignore_All_Changes_To_Type.target.cs
+++ b/src/Uno.PackageDiff.Tests/Sources/Given_ReportAnalyzer_When_Ignore_All_Changes_To_Type.target.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Uno.PackageDiff.Tests.Sources
+{
+	public class When_Ignore_All_Changes_To_Type
+	{
+	}
+}

--- a/src/Uno.PackageDiff/ReportAnalyzer.cs
+++ b/src/Uno.PackageDiff/ReportAnalyzer.cs
@@ -9,7 +9,7 @@ namespace Uno.PackageDiff
 	{
 		public static bool IsDiffFailed(ComparisonResult results, IgnoreSet ignoreSet)
 		{
-			var ignoredTypes = ignoreSet.Types.Select(t2 => t2.FullName);
+			var ignoredTypes = ignoreSet?.Types.Select(t2 => t2.FullName);
 			var failedTypes = results.InvalidTypes.Any(t => !ignoredTypes.Contains(t.ToSignature()));
 			var failedEvents = results.InvalidEvents.Any(e => !ignoreSet.Events.Select(t => t.FullName).Contains(e.ToSignature())
 				&& !ignoredTypes.Contains(e.DeclaringType.ToSignature()));

--- a/src/Uno.PackageDiff/ReportAnalyzer.cs
+++ b/src/Uno.PackageDiff/ReportAnalyzer.cs
@@ -9,11 +9,16 @@ namespace Uno.PackageDiff
 	{
 		public static bool IsDiffFailed(ComparisonResult results, IgnoreSet ignoreSet)
 		{
-			var failedTypes = results.InvalidTypes.Any(t => !ignoreSet.Types.Select(t2 => t2.FullName).Contains(t.ToSignature()));
-			var failedEvents = results.InvalidEvents.Any(e => !ignoreSet.Events.Select(t => t.FullName).Contains(e.ToSignature()));
-			var failedFields = results.InvalidFields.Any(f => !ignoreSet.Fields.Select(t => t.FullName).Contains(f.ToSignature()));
-			var failedMethods = results.InvalidMethods.Any(m => !ignoreSet.Methods.Select(t => t.FullName).Contains(m.ToSignature()));
-			var failedProperties = results.InvalidProperties.Any(p => !ignoreSet.Properties.Select(t => t.FullName).Contains(p.ToSignature()));
+			var ignoredTypes = ignoreSet.Types.Select(t2 => t2.FullName);
+			var failedTypes = results.InvalidTypes.Any(t => !ignoredTypes.Contains(t.ToSignature()));
+			var failedEvents = results.InvalidEvents.Any(e => !ignoreSet.Events.Select(t => t.FullName).Contains(e.ToSignature())
+				&& !ignoredTypes.Contains(e.DeclaringType.ToSignature()));
+			var failedFields = results.InvalidFields.Any(f => !ignoreSet.Fields.Select(t => t.FullName).Contains(f.ToSignature())
+				&& !ignoredTypes.Contains(f.DeclaringType.ToSignature()));
+			var failedMethods = results.InvalidMethods.Any(m => !ignoreSet.Methods.Select(t => t.FullName).Contains(m.ToSignature())
+				&& !ignoredTypes.Contains(m.DeclaringType.ToSignature()));
+			var failedProperties = results.InvalidProperties.Any(p => !ignoreSet.Properties.Select(t => t.FullName).Contains(p.ToSignature())
+				&& !ignoredTypes.Contains(p.DeclaringType.ToSignature()));
 
 			return failedTypes
 				|| failedEvents


### PR DESCRIPTION
If a type is in the Types of an ignore file, but is not actually removed, ignore all removed members on that type instead.

In general ignoring individual members explicitly is preferable, but this option is useful in certain special cases, eg breaking changes involving large numbers of properties coming from generated code.

GitHub Issue (If applicable): https://github.com/unoplatform/uno/issues/119
<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

<!-- - Bugfix -->
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?
<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
