### PR TITLE
fix: Types that became internal were not being detected as removed

### DIFF
--- a/src/Uno.PackageDiff.Tests/Given_AssemblyComparer.cs
+++ b/src/Uno.PackageDiff.Tests/Given_AssemblyComparer.cs
@@ -98,5 +98,21 @@ namespace Uno.PackageDiff.Tests
 			Assert.AreEqual("TestMethod", r.InvalidMethods.ElementAt(0).Name);
 			Assert.AreEqual("System.Threading.Tasks.Task Uno.PackageDiff.Tests.Sources.When_Target_Method_ChangedReturnType::TestMethod()", r.InvalidMethods.ElementAt(0).ToString());
 		}
+
+		[TestMethod]
+		public void When_Target_Type_Internal()
+		{
+			var context = _builder.BuildAssemblies();
+
+			var r = AssemblyComparer.CompareTypes(context.BaseAssembly, context.TargetAssembly);
+
+			Assert.AreEqual(1, r.InvalidTypes.Length);
+
+			// Changed members of removed (no longer visible) types shouldn't be flagged
+			Assert.AreEqual(0, r.InvalidEvents.Length);
+			Assert.AreEqual(0, r.InvalidFields.Length);
+			Assert.AreEqual(0, r.InvalidMethods.Length);
+			Assert.AreEqual(0, r.InvalidProperties.Length);
+		}
 	}
 }

--- a/src/Uno.PackageDiff.Tests/Sources/Given_AssemblyComparer_When_Target_Type_Internal.base.cs
+++ b/src/Uno.PackageDiff.Tests/Sources/Given_AssemblyComparer_When_Target_Type_Internal.base.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Uno.PackageDiff.Tests.Sources
+{
+	public class When_Target_Type_Internal
+	{
+		public int MyProperty { get; set; }
+
+		public void MyMethod() { }
+	}
+}

--- a/src/Uno.PackageDiff.Tests/Sources/Given_AssemblyComparer_When_Target_Type_Internal.target.cs
+++ b/src/Uno.PackageDiff.Tests/Sources/Given_AssemblyComparer_When_Target_Type_Internal.target.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Uno.PackageDiff.Tests.Sources
+{
+	internal class When_Target_Type_Internal
+	{
+		public double MyProperty { get; set; }
+
+		public void MyMethod(int newParam) { }
+	}
+}

--- a/src/Uno.PackageDiff/AssemblyComparer.cs
+++ b/src/Uno.PackageDiff/AssemblyComparer.cs
@@ -36,20 +36,20 @@ namespace Uno.PackageDiff
 			var baseTypes = baseAssembly.MainModule.GetTypes();
 			var targetTypes = targetAssembly.MainModule.GetTypes();
 
-			// Types only in target
-			var q = from targetType in baseTypes
-					where !targetTypes.Any(t => t.FullName == targetType.FullName)
-					where targetType.IsPublic
-					select targetType;
+			// Types only in base
+			var q = from baseType in baseTypes
+					where baseType.IsPublic
+					where !targetTypes.Any(t => t.FullName == baseType.FullName && t.IsPublic)
+					select baseType;
 
 			var invalidTypes = q.ToArray();
 
 			var existingTypes = (
-				from targetType in baseTypes
-				let sourceType = targetTypes.FirstOrDefault(t => t.FullName == targetType.FullName)
-				where sourceType != null
-				where targetType.IsPublic
-				select (sourceType, targetType)
+				from baseType in baseTypes
+				where baseType.IsPublic
+				let sourceType = targetTypes.FirstOrDefault(t => t.FullName == baseType.FullName)
+				where sourceType != null && sourceType.IsPublic
+				select (sourceType, baseType)
 			).ToArray();
 
 			var invalidProperties = FindMissingProperties(existingTypes);


### PR DESCRIPTION
Previously, removed types were only flagged if removed completely, and mistakenly ignored if only their visibility had changed.

GitHub Issue (If applicable): #
<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

- Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?
<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
